### PR TITLE
Fix theme switching

### DIFF
--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -1,14 +1,9 @@
 import { Fragment } from "react";
-import ThemeLayout from "@/components/theme-layout";
 
 export default async function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  return (
-    <ThemeLayout overrideTheme="dark">
-      <Fragment>{children}</Fragment>
-    </ThemeLayout>
-  );
+  return <Fragment>{children}</Fragment>;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import "./codemirror-override.css";
 import "./globals.css";
 
 import { DialogProvider } from "@/components/create-dialog";
+import ThemeLayout from "@/components/theme-layout";
 
 export const metadata: Metadata = {
   title: WEBSITE_NAME,
@@ -34,8 +35,10 @@ export default async function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body>
-        {children}
-        <DialogProvider slot="default" />
+        <ThemeLayout>
+          {children}
+          <DialogProvider slot="default" />
+        </ThemeLayout>
       </body>
     </html>
   );

--- a/src/components/theme-layout.tsx
+++ b/src/components/theme-layout.tsx
@@ -15,7 +15,7 @@ export default function ThemeLayout({
   overrideThemeVariables?: Record<string, string>;
 }>) {
   useEffect(() => {
-    if (overrideThemeVariables && typeof window === "undefined") {
+    if (overrideThemeVariables && typeof window !== "undefined") {
       Object.entries(overrideThemeVariables).forEach(([key, value]) => {
         document.body.style.setProperty(key, value);
       });


### PR DESCRIPTION
Fixed three critical issues preventing theme switching:
1. Added ThemeLayout provider to root layout.tsx - the main app was missing theme context
2. Fixed server-side check bug in theme-layout.tsx (line 18) - was checking for server but accessing client-only document.body
3. Removed forced dark theme from (public) layout to enable consistent theme switching across all routes

Theme toggle in sidebar now works correctly across the entire application.